### PR TITLE
add the ability to select the source, with media.ccc.de by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,25 @@ $ $GOPATH/bin/sync3c -language eng -destination /my/downloads
 ...
 ```
 
+#### List events from an alternate source
+```
+$ $GOPATH/bin/sync3c -source media.freifunk.net list
+Conference: misc (Verschiedene Beiträge)
+Conference: 35c3oio (35c3 - Open Infrastructure Orbit)
+Conference: 36c3oio (36c3 - Open Infrastructure Orbit)
+Conference: wcw2018 (Wireless Meshup)
+Conference: bmv12 (Battlemesh v12)
+...
+```
+
+### Download all talks from an alternate source
+```
+$ $GOPATH/bin/sync3c -source media.freifunk.net -name bmv12 -language eng
+Conference: bmv12 (Battlemesh v12)
+Event: Models for affordable and universal networks: public infrastructure and community networks - This panel will focus on a central question: ...
+        Found video (video/mp4): 54 minutes, 1920x1080 (HD: true, 785MiB) https://api.media.freifunk.net/public/recordings/214
+        Found video (video/webm): 54 minutes, 1920x1080 (HD: true, 508MiB) https://api.media.freifunk.net/public/recordings/213
+...
+```
+
 Enjoy the great content!

--- a/sync3c.go
+++ b/sync3c.go
@@ -68,7 +68,7 @@ func main() {
 	flag.StringVar(&name, "name", "", "download media of a specific conference only (e.g. '33c3')")
 	flag.StringVar(&downloadPath, "destination", "./downloads/", "where to store downloaded media")
 	flag.StringVar(&language, "language", "", "preferred language if available (eng, deu or fra)")
-	flag.StringVar(&source, "source", "", "source of conferences (e.g. 'media.ccc.de', 'media.freifunk.net'")
+	flag.StringVar(&source, "source", "media.ccc.de", "source of conferences (e.g. 'media.freifunk.net'")
 	flag.Parse()
 
 	if len(flag.Args()) > 0 {
@@ -87,11 +87,7 @@ func main() {
 	extensionForMimeTypes["audio/opus"] = "opus"
 	extensionForMimeTypes["audio/mpeg"] = "mp3"
 
-	if len(source) == 0 {
-		source = "media.ccc.de"
-	}
-	source := fmt.Sprintf("https://api.%s/public/conferences", source)
-	ci, err := findConferences(source)
+	ci, err := findConferences(fmt.Sprintf("https://api.%s/public/conferences", source))
 	if err != nil {
 		panic(err)
 	}

--- a/sync3c.go
+++ b/sync3c.go
@@ -19,6 +19,7 @@ var (
 	downloadPath string
 	name         string
 	language     string
+	source       string
 	listOnly     bool
 )
 
@@ -67,6 +68,7 @@ func main() {
 	flag.StringVar(&name, "name", "", "download media of a specific conference only (e.g. '33c3')")
 	flag.StringVar(&downloadPath, "destination", "./downloads/", "where to store downloaded media")
 	flag.StringVar(&language, "language", "", "preferred language if available (eng, deu or fra)")
+	flag.StringVar(&source, "source", "", "source of conferences (e.g. 'media.ccc.de', 'media.freifunk.net'")
 	flag.Parse()
 
 	if len(flag.Args()) > 0 {
@@ -76,6 +78,7 @@ func main() {
 
 	name = strings.ToLower(name)
 	language = strings.ToLower(language)
+	source = strings.ToLower(source)
 
 	extensionForMimeTypes["video/webm"] = "webm"
 	extensionForMimeTypes["video/mp4"] = "mp4"
@@ -84,7 +87,11 @@ func main() {
 	extensionForMimeTypes["audio/opus"] = "opus"
 	extensionForMimeTypes["audio/mpeg"] = "mp3"
 
-	ci, err := findConferences("https://api.media.ccc.de/public/conferences")
+	if len(source) == 0 {
+		source = "media.ccc.de"
+	}
+	source := fmt.Sprintf("https://api.%s/public/conferences", source)
+	ci, err := findConferences(source)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Freifunk uses the same software as ccc for their conference videos, so I'd 
suggest adding a -source arg in order to choose from which source to download.
By default, it's still media.ccc.de

In order to list the events, if the source is not media.ccc.de, it has to be specified first:

    sync3c -source media.freifunk.net list